### PR TITLE
addin GEO XREF downloads to Ferret for the Loader: JIRA AGR-2069

### DIFF
--- a/src/datasets/GeoXref.yaml
+++ b/src/datasets/GeoXref.yaml
@@ -1,0 +1,62 @@
+id: GEOXREF
+contact_email: alliance-architecture@lists.stanford.edu 
+project_url: alliancegenome.org
+datasets:
+  -
+    id: ZFIN
+    filename: zfin.geo.xref.xml
+    url: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?term=gene_geoprofiles[filter]+AND+Danio+rerio[Organism]&retmax=100000&db=gene"
+    filetype: xml
+    type: GEOXREF
+    subtype: ZFIN
+    status: active
+  -
+    id: SGD
+    filename: sgd.geo.xref.xml
+    url: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?term=gene_geoprofiles[filter]+AND+Saccharomyces+cerevisiae[Organism]&retmax=100000&db=gene"
+    filetype: xml
+    type: GEOXREF
+    subtype: SGD
+    status: active
+  -
+    id: WB
+    filename: wb.geo.xref.xml
+    url: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?term=gene_geoprofiles[filter]+AND+Caenorhabditis+elegans[Organism]&retmax=100000&db=gene"
+    filetype: xml
+    type: GEOXREF
+    subtype: WB
+    status: active
+  -
+    id: MGI
+    filename: mgi.geo.xref.xml
+    url: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?term=gene_geoprofiles[filter]+AND+Mus+musculus[Organism]&retmax=100000&db=gene"
+
+    filetype: xml
+    type: GEOXREF
+    subtype: MGI
+    status: active
+  -
+    id: FB
+    filename: fb.geo.xref.xml
+    url: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?term=gene_geoprofiles[filter]+AND+Drosophila+melanogaster[Organism]&retmax=100000&db=gene"
+    filetype: xml
+    type: GEOXREF
+    subtype: FB
+    status: active
+  -
+    id: RGD
+    filename: rgd.geo.xref.xml
+    url: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?term=gene_geoprofiles[filter]+AND+Rattus+norvegicus[Organism]&retmax=100000&db=gene"
+    filetype: xml
+    type: GEOXREF
+    subtype: RGD
+    status: active
+  -
+    id: HUMAN
+    filename: human.geo.xref.axml
+    url: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?term=gene_geoprofiles[filter]+AND+Homo+sapiens[Organism]&retmax=100000&db=gene"
+
+    filetype: xml
+    type: GEOXREF
+    subtype: HUMAN
+    status: active

--- a/src/datasets/GeoXref.yaml
+++ b/src/datasets/GeoXref.yaml
@@ -30,7 +30,6 @@ datasets:
     id: MGI
     filename: mgi.geo.xref.xml
     url: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?term=gene_geoprofiles[filter]+AND+Mus+musculus[Organism]&retmax=100000&db=gene"
-
     filetype: xml
     type: GEOXREF
     subtype: MGI
@@ -55,7 +54,6 @@ datasets:
     id: HUMAN
     filename: human.geo.xref.axml
     url: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?term=gene_geoprofiles[filter]+AND+Homo+sapiens[Organism]&retmax=100000&db=gene"
-
     filetype: xml
     type: GEOXREF
     subtype: HUMAN

--- a/src/validation/validation.yaml
+++ b/src/validation/validation.yaml
@@ -1,7 +1,7 @@
 id:
   type: string
   required: True
-  allowed: [FB, WB, ONTOLOGY, GAF, GENEEEXPRESSIONATLASSITEMAP, IMEX]
+  allowed: [FB, WB, ONTOLOGY, GAF, GENEEEXPRESSIONATLASSITEMAP, GEOXREF, IMEX]
 contact_email:
   type: string
   required: True
@@ -41,7 +41,7 @@ datasets:
       type:
         type: string
         required: True
-        allowed: [BGI, ONTOLOGY, GAF, GENEEEXPRESSIONATLASSITEMAP, INTERACTION-SOURCE]
+        allowed: [BGI, ONTOLOGY, GAF, GENEEEXPRESSIONATLASSITEMAP, GEOXREF, INTERACTION-SOURCE]
       subtype: 
         type: string
         required: True


### PR DESCRIPTION
I have created GEOXREF datatype and subtypes in FMS and then have added them here. The intention is to have them be downloaded by Ferret instead of when the loader runs the first time. This will ensure we get updates and can track the file versions we have been working with. 

After this is working we should change the loader. I will make a ticket for the loader work.