### PR TITLE
ZECO ontology added

### DIFF
--- a/src/datasets/ONTOLOGY.yaml
+++ b/src/datasets/ONTOLOGY.yaml
@@ -219,6 +219,14 @@ datasets:
     subtype: WBPhenotype
     status: active
   -
+    id: ZECO
+    filename: zeco.obo
+    url: http://purl.obolibrary.org/obo/zeco.obo
+    filetype: obo
+    type: ONTOLOGY
+    subtype: ZECO
+    status: active
+  -
     id: ZFA
     filename: zfa.obo
     url: http://purl.obolibrary.org/obo/zfa.obo

--- a/src/validation/validation.yaml
+++ b/src/validation/validation.yaml
@@ -45,4 +45,6 @@ datasets:
       subtype: 
         type: string
         required: True
-        allowed: [ZFIN, RGD, SGD, MGI, WB, HUMAN, FB, ZFA, ZFS, GO, MI, MMO, UBERON, ECO, WBBT, FBBT, MA, CL, DOID, MMUSDV, EMAPA, BSPO, FBCV, SO, WBLS, ECOMAP, MI, IMEX, HP, MP, APO, WBPhenotype, PATO, DPO, FYPO, OBI, CHEBI, BTO, BIOGRID, BIOGRID-TAB]
+        allowed: [ZFIN, RGD, SGD, MGI, WB, HUMAN, FB, APO, BIOGRID, BIOGRID-TAB, BSPO, BTO, CHEBI, CL,
+                  DOID, DPO, ECO, ECOMAP, EMAPA, FBBT, FBCV, FYPO, GO, HP, IMEX, MA, MI, MI, MMO, MMUSDV, MP,
+                  OBI, PATO, SO, UBERON, WBBT, WBLS, WBPhenotype, ZECO, ZFA, ZFS]


### PR DESCRIPTION
subtype allowed list now starts with the mods and then the others are in alphabetical order and split over multiple lines  to enable eyeballing easier.
ZECO added to ontology last and new subtype added.