### PR TITLE
Update GAF.yaml with temporary Xenbase GAF location

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,8 +1,7 @@
 name: Test Build Docker image
 on:
-  push:
-    branches:
-      - SCRUM-912
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
   build-docker-image:

--- a/src/datasets/GAF.yaml
+++ b/src/datasets/GAF.yaml
@@ -63,3 +63,11 @@ datasets:
     type: GAF
     subtype: HUMAN
     status: active
+  -
+    id: Xenbase
+    filename: xenbase.EBI.only.2.2.gaf
+    url: https://ftp.xenbase.org/pub/DataExchange/GO/xenbase.EBI.only.2.2.gaf.gz
+    filetype: gaf
+    type: GAF
+    subtype: Xenbase
+    status: active


### PR DESCRIPTION
Added temporary GAF location to for Xenbase. This will be updated once GO finishes their Xenbase production pipeline. Adding it from Xenbase directly will allow @valearna do begin work on the automated gene descriptions while we wait for GO.